### PR TITLE
Revamp UI with light theme, ROI editing and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 Android app for counting swim laps using camera motion detection and sound detection.
 
 Features:
-- Adjustable camera sensitivity and region of interest
+- Adjustable camera sensitivity and editable region of interest (ROI)
+- Live camera preview with draggable and resizable ROI overlay
 - Audio threshold detection
-- Configurable lane length and laps-to-distance calculation
+- Configurable lane length, turns-per-lap and debounce interval
+- Light/Dark theme with high contrast
+- Settings menu for all options with persistence
 - Displays lap count, total distance and recent intervals with large text
 
 This project uses Jetpack Compose, CameraX and AudioRecord APIs. It is designed to be
@@ -21,3 +24,7 @@ available tasks:
 gradle wrapper
 ./gradlew tasks
 ```
+
+The settings menu can be opened from the top-right settings icon on the main screen.
+Here you can enable/disable camera or sound counting, adjust detection thresholds,
+change the lane length, theme and ROI.

--- a/app/src/main/java/com/example/svommeapp/LapCounterViewModel.kt
+++ b/app/src/main/java/com/example/svommeapp/LapCounterViewModel.kt
@@ -1,6 +1,9 @@
 package com.example.svommeapp
 
-import androidx.lifecycle.ViewModel
+import android.app.Application
+import android.content.Context
+import android.graphics.RectF
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -8,10 +11,13 @@ import kotlinx.coroutines.launch
 
 /**
  * ViewModel holding all lap counting logic and settings.
- * The two detector classes report events via [onTurnDetected], which will
- * update lap count and interval information.
+ * Settings are persisted in SharedPreferences so the app remembers the
+ * configuration and ROI between sessions.
  */
-class LapCounterViewModel : ViewModel() {
+class LapCounterViewModel(app: Application) : AndroidViewModel(app) {
+    private val prefs = app.getSharedPreferences("settings", Context.MODE_PRIVATE)
+
+    // Lap data
     private val _laps = MutableStateFlow(0)
     val laps: StateFlow<Int> = _laps
 
@@ -21,26 +27,102 @@ class LapCounterViewModel : ViewModel() {
     private val _distanceMeters = MutableStateFlow(0)
     val distanceMeters: StateFlow<Int> = _distanceMeters
 
-    // Settings
-    var laneLengthMeters: Int = 25
-    var sensitivity: Float = 0.5f
-    var audioThresholdDb: Int = 80
-    var roiX: Float = 0.3f
-    var roiY: Float = 0.3f
-    var roiW: Float = 0.4f
-    var roiH: Float = 0.4f
-    var minIntervalMs: Long = 2000
-    var turnsPerLap: Int = 2
+    // Settings flows
+    private val _cameraEnabled = MutableStateFlow(prefs.getBoolean("cameraEnabled", false))
+    val cameraEnabled: StateFlow<Boolean> = _cameraEnabled
+
+    private val _soundEnabled = MutableStateFlow(prefs.getBoolean("soundEnabled", false))
+    val soundEnabled: StateFlow<Boolean> = _soundEnabled
+
+    private val _laneLengthMeters = MutableStateFlow(prefs.getInt("laneLength", 25))
+    val laneLengthMeters: StateFlow<Int> = _laneLengthMeters
+
+    private val _sensitivity = MutableStateFlow(prefs.getFloat("sensitivity", 0.5f))
+    val sensitivity: StateFlow<Float> = _sensitivity
+
+    private val _audioThresholdDb = MutableStateFlow(prefs.getInt("audioThreshold", 80))
+    val audioThresholdDb: StateFlow<Int> = _audioThresholdDb
+
+    private val _roi = MutableStateFlow(
+        RectF(
+            prefs.getFloat("roiX", 0.3f),
+            prefs.getFloat("roiY", 0.3f),
+            prefs.getFloat("roiX", 0.3f) + prefs.getFloat("roiW", 0.4f),
+            prefs.getFloat("roiY", 0.3f) + prefs.getFloat("roiH", 0.4f)
+        )
+    )
+    val roi: StateFlow<RectF> = _roi
+
+    private val _minIntervalMs = MutableStateFlow(prefs.getLong("minInterval", 2000))
+    val minIntervalMs: StateFlow<Long> = _minIntervalMs
+
+    private val _turnsPerLap = MutableStateFlow(prefs.getInt("turnsPerLap", 2))
+    val turnsPerLap: StateFlow<Int> = _turnsPerLap
+
+    private val _themeMode = MutableStateFlow(
+        ThemeMode.valueOf(prefs.getString("themeMode", ThemeMode.AUTO.name)!!)
+    )
+    val themeMode: StateFlow<ThemeMode> = _themeMode
 
     private var lastTriggerTime: Long = 0
 
+    fun setCameraEnabled(enabled: Boolean) {
+        _cameraEnabled.value = enabled
+        prefs.edit().putBoolean("cameraEnabled", enabled).apply()
+    }
+
+    fun setSoundEnabled(enabled: Boolean) {
+        _soundEnabled.value = enabled
+        prefs.edit().putBoolean("soundEnabled", enabled).apply()
+    }
+
+    fun updateLaneLength(meters: Int) {
+        _laneLengthMeters.value = meters
+        prefs.edit().putInt("laneLength", meters).apply()
+    }
+
+    fun updateSensitivity(value: Float) {
+        _sensitivity.value = value
+        prefs.edit().putFloat("sensitivity", value).apply()
+    }
+
+    fun updateAudioThreshold(db: Int) {
+        _audioThresholdDb.value = db
+        prefs.edit().putInt("audioThreshold", db).apply()
+    }
+
+    fun updateMinInterval(ms: Long) {
+        _minIntervalMs.value = ms
+        prefs.edit().putLong("minInterval", ms).apply()
+    }
+
+    fun updateTurnsPerLap(value: Int) {
+        _turnsPerLap.value = value
+        prefs.edit().putInt("turnsPerLap", value).apply()
+    }
+
+    fun updateThemeMode(mode: ThemeMode) {
+        _themeMode.value = mode
+        prefs.edit().putString("themeMode", mode.name).apply()
+    }
+
+    fun updateRoi(rect: RectF) {
+        _roi.value = rect
+        prefs.edit()
+            .putFloat("roiX", rect.left)
+            .putFloat("roiY", rect.top)
+            .putFloat("roiW", rect.width())
+            .putFloat("roiH", rect.height())
+            .apply()
+    }
+
     fun onTurnDetected(timestamp: Long = System.currentTimeMillis()) {
-        if (timestamp - lastTriggerTime < minIntervalMs) return
+        if (timestamp - lastTriggerTime < _minIntervalMs.value) return
         lastTriggerTime = timestamp
         viewModelScope.launch {
             val newLaps = _laps.value + 1
             _laps.emit(newLaps)
-            _distanceMeters.emit(newLaps * laneLengthMeters / turnsPerLap)
+            _distanceMeters.emit(newLaps * _laneLengthMeters.value / _turnsPerLap.value)
             val times = (_lastLapTimes.value + timestamp).takeLast(3)
             _lastLapTimes.emit(times)
         }

--- a/app/src/main/java/com/example/svommeapp/MainActivity.kt
+++ b/app/src/main/java/com/example/svommeapp/MainActivity.kt
@@ -1,48 +1,73 @@
 package com.example.svommeapp
 
 import android.Manifest
-import android.graphics.Rect
+import android.graphics.RectF
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import androidx.core.content.ContextCompat
 import com.example.svommeapp.detector.MotionDetector
 import com.example.svommeapp.detector.SoundDetector
+import com.example.svommeapp.ui.theme.SvommeTheme
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
 class MainActivity : ComponentActivity() {
     private val vm: LapCounterViewModel by viewModels()
     private var motionDetector: MotionDetector? = null
     private var soundDetector: SoundDetector? = null
+    private var cameraProvider: ProcessCameraProvider? = null
 
     @OptIn(ExperimentalPermissionsApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         setContent {
             val permissions = rememberMultiplePermissionsState(
                 listOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
             )
             LaunchedEffect(Unit) { permissions.launchMultiplePermissionRequest() }
-            if (!permissions.allPermissionsGranted) {
-                Text("Camera and microphone permissions are required")
-            } else {
-                MainScreen()
+            val theme by vm.themeMode.collectAsState()
+            SvommeTheme(theme) {
+                if (!permissions.allPermissionsGranted) {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("Camera and microphone permissions are required")
+                    }
+                } else {
+                    MainScreen()
+                }
             }
         }
     }
@@ -52,66 +77,122 @@ class MainActivity : ComponentActivity() {
         val laps by vm.laps.collectAsState()
         val distance by vm.distanceMeters.collectAsState()
         val lapTimes by vm.lastLapTimes.collectAsState()
-        var cameraEnabled by remember { mutableStateOf(false) }
-        var soundEnabled by remember { mutableStateOf(false) }
-        val executor = remember { Executors.newSingleThreadExecutor() }
+        val cameraEnabled by vm.cameraEnabled.collectAsState()
+        val soundEnabled by vm.soundEnabled.collectAsState()
+        val roi by vm.roi.collectAsState()
+        val sensitivity by vm.sensitivity.collectAsState()
+        val audioThreshold by vm.audioThresholdDb.collectAsState()
+        val laneLength by vm.laneLengthMeters.collectAsState()
+        val minInterval by vm.minIntervalMs.collectAsState()
+        val turnsPerLap by vm.turnsPerLap.collectAsState()
+        val themeMode by vm.themeMode.collectAsState()
 
-        Column(Modifier.fillMaxSize().padding(16.dp)) {
-            Text("Laps: $laps", fontSize = 48.sp, fontWeight = FontWeight.Bold)
-            Text("Distance: ${distance}m (${distance/1000f}km)", fontSize = 24.sp)
-            Text("Last intervals:", fontWeight = FontWeight.Bold)
-            lapTimes.takeLast(3).zipWithNext { a, b -> b - a }.forEach {
-                Text("${it/1000f}s")
+        val context = LocalContext.current
+        val lifecycleOwner = LocalLifecycleOwner.current
+        val executor = remember { Executors.newSingleThreadExecutor() }
+        val previewView = remember { PreviewView(context) }
+        var showSettings by remember { mutableStateOf(false) }
+
+        LaunchedEffect(cameraEnabled, roi, sensitivity) {
+            if (cameraEnabled) {
+                startCamera(previewView, executor, roi, sensitivity, lifecycleOwner)
+            } else {
+                stopCamera()
             }
-            Spacer(modifier = Modifier.height(16.dp))
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("Camera")
-                Switch(cameraEnabled, {
-                    cameraEnabled = it
-                    if (it) startCamera(executor) else stopCamera()
-                })
+        }
+
+        LaunchedEffect(soundEnabled, audioThreshold) {
+            if (soundEnabled) startSound(audioThreshold) else stopSound()
+        }
+
+        Scaffold(topBar = {
+            TopAppBar(title = { Text("Svømme") }, actions = {
+                IconButton(onClick = { showSettings = true }) {
+                    Icon(Icons.Default.Settings, contentDescription = "Settings")
+                }
+            })
+        }) { padding ->
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+            ) {
+                Box(Modifier.weight(1f).fillMaxWidth()) {
+                    AndroidView({ previewView }, modifier = Modifier.fillMaxSize())
+                    RoiOverlay(roi = roi, onChange = { vm.updateRoi(it) })
+                }
+                Column(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text("$laps", fontSize = 96.sp, fontWeight = FontWeight.Bold)
+                    Text("Omgange", fontSize = 20.sp)
+                    Text("${distance} m", fontSize = 48.sp, fontWeight = FontWeight.Bold)
+                    Text("Distance", fontSize = 20.sp)
+                    Text("Intervaller", fontWeight = FontWeight.Bold, modifier = Modifier.padding(top = 8.dp))
+                    val intervals = lapTimes.takeLast(3).zipWithNext { a, b -> b - a }
+                    intervals.forEach { Text("${it/1000f}s", fontSize = 32.sp) }
+                }
             }
-            if (!cameraEnabled) {
-                Text("Kamera-tælling er slået fra")
-            }
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text("Microphone")
-                Switch(soundEnabled, {
-                    soundEnabled = it
-                    if (it) startSound() else stopSound()
-                })
-            }
-            Spacer(Modifier.height(8.dp))
-            Text("Lane length (m)")
-            var lane by remember { mutableStateOf(vm.laneLengthMeters.toString()) }
-            TextField(lane, {
-                lane = it
-                vm.laneLengthMeters = it.toIntOrNull() ?: vm.laneLengthMeters
-            }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number))
+        }
+
+        if (showSettings) {
+            SettingsDialog(
+                cameraEnabled = cameraEnabled,
+                onCameraEnabledChange = vm::setCameraEnabled,
+                soundEnabled = soundEnabled,
+                onSoundEnabledChange = vm::setSoundEnabled,
+                sensitivity = sensitivity,
+                onSensitivityChange = vm::updateSensitivity,
+                audioThreshold = audioThreshold,
+                onAudioThresholdChange = vm::updateAudioThreshold,
+                laneLength = laneLength,
+                onLaneLengthChange = vm::updateLaneLength,
+                minInterval = minInterval,
+                onMinIntervalChange = vm::updateMinInterval,
+                turnsPerLap = turnsPerLap,
+                onTurnsPerLapChange = vm::updateTurnsPerLap,
+                themeMode = themeMode,
+                onThemeModeChange = vm::updateThemeMode,
+                onDismiss = { showSettings = false }
+            )
         }
     }
 
-    private fun startCamera(executor: java.util.concurrent.Executor) {
+    private fun startCamera(
+        previewView: PreviewView,
+        executor: Executor,
+        roi: RectF,
+        sensitivity: Float,
+        lifecycleOwner: androidx.lifecycle.LifecycleOwner
+    ) {
         val providerFuture = ProcessCameraProvider.getInstance(this)
         providerFuture.addListener({
             val provider = providerFuture.get()
+            cameraProvider = provider
+            val preview = Preview.Builder().build().also {
+                it.setSurfaceProvider(previewView.surfaceProvider)
+            }
             val analysis = ImageAnalysis.Builder().build()
-            val roi = Rect(0, 0, 100, 100) // Placeholder ROI
-            motionDetector = MotionDetector(roi, vm.sensitivity) {
+            motionDetector = MotionDetector(roi, sensitivity) {
                 vm.onTurnDetected()
             }
             analysis.setAnalyzer(executor, motionDetector!!)
             provider.unbindAll()
-            provider.bindToLifecycle(this, CameraSelector.DEFAULT_BACK_CAMERA, analysis)
+            provider.bindToLifecycle(lifecycleOwner, CameraSelector.DEFAULT_BACK_CAMERA, preview, analysis)
         }, ContextCompat.getMainExecutor(this))
     }
 
     private fun stopCamera() {
         motionDetector = null
+        cameraProvider?.unbindAll()
+        cameraProvider = null
     }
 
-    private fun startSound() {
-        soundDetector = SoundDetector(vm.audioThresholdDb) {
+    private fun startSound(threshold: Int) {
+        soundDetector = SoundDetector(threshold) {
             vm.onTurnDetected()
         }
         soundDetector?.start()
@@ -120,5 +201,137 @@ class MainActivity : ComponentActivity() {
     private fun stopSound() {
         soundDetector?.stop()
         soundDetector = null
+    }
+}
+
+@Composable
+private fun RoiOverlay(roi: RectF, onChange: (RectF) -> Unit) {
+    var parentSize by remember { mutableStateOf(IntSize.Zero) }
+    val density = LocalDensity.current
+    Box(Modifier.fillMaxSize().onSizeChanged { parentSize = it }) {
+        if (parentSize != IntSize.Zero) {
+            var rect by remember { mutableStateOf(roi) }
+            LaunchedEffect(roi) { rect = roi }
+            val width = with(density) { (rect.width() * parentSize.width).toDp() }
+            val height = with(density) { (rect.height() * parentSize.height).toDp() }
+            val offsetX = with(density) { (rect.left * parentSize.width).toDp() }
+            val offsetY = with(density) { (rect.top * parentSize.height).toDp() }
+            Box(
+                Modifier
+                    .offset(x = offsetX, y = offsetY)
+                    .size(width, height)
+                    .border(BorderStroke(2.dp, MaterialTheme.colors.primary))
+                    .pointerInput(parentSize) {
+                        detectTransformGestures { _, pan, zoom, _ ->
+                            var newWidth = rect.width() * zoom
+                            var newHeight = rect.height() * zoom
+                            newWidth = newWidth.coerceIn(0.05f, 1f)
+                            newHeight = newHeight.coerceIn(0.05f, 1f)
+                            var left = rect.left + pan.x / parentSize.width
+                            var top = rect.top + pan.y / parentSize.height
+                            left = left.coerceIn(0f, 1f - newWidth)
+                            top = top.coerceIn(0f, 1f - newHeight)
+                            rect = RectF(left, top, left + newWidth, top + newHeight)
+                            onChange(rect)
+                        }
+                    }
+            ) {
+                val handleModifier = Modifier.size(16.dp).background(MaterialTheme.colors.primary)
+                Box(handleModifier.align(Alignment.TopStart))
+                Box(handleModifier.align(Alignment.TopEnd))
+                Box(handleModifier.align(Alignment.BottomStart))
+                Box(handleModifier.align(Alignment.BottomEnd))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsDialog(
+    cameraEnabled: Boolean,
+    onCameraEnabledChange: (Boolean) -> Unit,
+    soundEnabled: Boolean,
+    onSoundEnabledChange: (Boolean) -> Unit,
+    sensitivity: Float,
+    onSensitivityChange: (Float) -> Unit,
+    audioThreshold: Int,
+    onAudioThresholdChange: (Int) -> Unit,
+    laneLength: Int,
+    onLaneLengthChange: (Int) -> Unit,
+    minInterval: Long,
+    onMinIntervalChange: (Long) -> Unit,
+    turnsPerLap: Int,
+    onTurnsPerLapChange: (Int) -> Unit,
+    themeMode: ThemeMode,
+    onThemeModeChange: (ThemeMode) -> Unit,
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(shape = MaterialTheme.shapes.large, color = MaterialTheme.colors.background) {
+            Column(
+                Modifier
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState())
+                    .width(300.dp)
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Camera counting", Modifier.weight(1f))
+                    Switch(cameraEnabled, onCameraEnabledChange)
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Sound counting", Modifier.weight(1f))
+                    Switch(soundEnabled, onSoundEnabledChange)
+                }
+                Spacer(Modifier.height(8.dp))
+                Text("Camera sensitivity: ${"%.2f".format(sensitivity)}")
+                Slider(value = sensitivity, onValueChange = onSensitivityChange, valueRange = 0f..1f)
+                Text("Audio threshold (dB): $audioThreshold")
+                Slider(
+                    value = audioThreshold.toFloat(),
+                    onValueChange = { onAudioThresholdChange(it.toInt()) },
+                    valueRange = 50f..120f
+                )
+                Spacer(Modifier.height(8.dp))
+                Text("Lane length (m)")
+                var laneText by remember { mutableStateOf(laneLength.toString()) }
+                TextField(
+                    laneText,
+                    onValueChange = {
+                        laneText = it
+                        it.toIntOrNull()?.let(onLaneLengthChange)
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("2 turns = 1 lap", Modifier.weight(1f))
+                    Switch(checked = turnsPerLap == 2, onCheckedChange = {
+                        onTurnsPerLapChange(if (it) 2 else 1)
+                    })
+                }
+                Spacer(Modifier.height(8.dp))
+                Text("Minimum interval (ms)")
+                var intervalText by remember { mutableStateOf(minInterval.toString()) }
+                TextField(
+                    intervalText,
+                    onValueChange = {
+                        intervalText = it
+                        it.toLongOrNull()?.let(onMinIntervalChange)
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                )
+                Spacer(Modifier.height(8.dp))
+                Text("Theme")
+                ThemeMode.values().forEach { mode ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        RadioButton(selected = themeMode == mode, onClick = { onThemeModeChange(mode) })
+                        Text(mode.name.lowercase().replaceFirstChar { c -> c.titlecase() })
+                    }
+                }
+                Spacer(Modifier.height(16.dp))
+                Button(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) {
+                    Text("Close")
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/svommeapp/ThemeMode.kt
+++ b/app/src/main/java/com/example/svommeapp/ThemeMode.kt
@@ -1,0 +1,3 @@
+package com.example.svommeapp
+
+enum class ThemeMode { AUTO, LIGHT, DARK }

--- a/app/src/main/java/com/example/svommeapp/detector/MotionDetector.kt
+++ b/app/src/main/java/com/example/svommeapp/detector/MotionDetector.kt
@@ -1,6 +1,7 @@
 package com.example.svommeapp.detector
 
 import android.graphics.Rect
+import android.graphics.RectF
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
 import kotlin.math.abs
@@ -11,7 +12,7 @@ import kotlin.math.abs
  * production ready but demonstrates how a detector could be structured.
  */
 class MotionDetector(
-    private val roi: Rect,
+    private val roiPercent: RectF,
     private val sensitivity: Float = 0.2f,
     private val onMotion: () -> Unit
 ) : ImageAnalysis.Analyzer {
@@ -22,6 +23,12 @@ class MotionDetector(
         val buffer = image.planes[0].buffer
         val data = ByteArray(buffer.remaining())
         buffer.get(data)
+        val roi = Rect(
+            (roiPercent.left * image.width).toInt(),
+            (roiPercent.top * image.height).toInt(),
+            (roiPercent.right * image.width).toInt(),
+            (roiPercent.bottom * image.height).toInt()
+        )
         if (lastFrame != null && lastFrame!!.size >= data.size) {
             var diffSum = 0
             var count = 0

--- a/app/src/main/java/com/example/svommeapp/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/svommeapp/ui/theme/Theme.kt
@@ -1,0 +1,47 @@
+package com.example.svommeapp.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
+import androidx.compose.material.Shapes
+import androidx.compose.material.Typography
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.example.svommeapp.ThemeMode
+
+private val LightColors = lightColors(
+    primary = Color(0xFF0066CC),
+    primaryVariant = Color(0xFF004999),
+    secondary = Color(0xFF03DAC5),
+    background = Color(0xFFFDFDFD),
+    surface = Color(0xFFFFFFFF),
+    onPrimary = Color.White,
+    onSecondary = Color.Black,
+    onBackground = Color.Black,
+    onSurface = Color.Black,
+)
+
+private val DarkColors = darkColors(
+    primary = Color(0xFF5B9BD5),
+    primaryVariant = Color(0xFF004999),
+    secondary = Color(0xFF03DAC5)
+)
+
+private val AppTypography = Typography()
+private val AppShapes = Shapes()
+
+@Composable
+fun SvommeTheme(mode: ThemeMode = ThemeMode.AUTO, content: @Composable () -> Unit) {
+    val darkTheme = when (mode) {
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+        ThemeMode.AUTO -> isSystemInDarkTheme()
+    }
+    MaterialTheme(
+        colors = if (darkTheme) DarkColors else LightColors,
+        typography = AppTypography,
+        shapes = AppShapes,
+        content = content
+    )
+}

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Theme.SvommeApp" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.SvommeApp" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorAccent">@color/teal_200</item>


### PR DESCRIPTION
## Summary
- Add light/dark `SvommeTheme` with high contrast colors
- Show CameraX preview with draggable ROI overlay and big lap/distance numbers
- Introduce persistent settings for camera/audio toggles, detection thresholds, lane length and theme

## Testing
- `gradle wrapper`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a49ed2648328b85acec6c9005d35