### PR TITLE
Add start/stop control and debug overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Features:
 - Light/Dark theme with high contrast
 - Settings menu for all options with persistence
 - Displays lap count, total distance and recent intervals with large text
+- Optional debug overlay with live detector values and event log
 
 This project uses Jetpack Compose, CameraX and AudioRecord APIs. It is designed to be
 extensible and well documented for future enhancements.
@@ -28,3 +29,26 @@ gradle wrapper
 The settings menu can be opened from the top-right settings icon on the main screen.
 Here you can enable/disable camera or sound counting, adjust detection thresholds,
 change the lane length, theme and ROI.
+
+### Controls & Settings
+
+- **Start/Stop** – the floating button toggles whether detections increment the
+  lap counter. Previews and levels continue to update while stopped.
+- **Sensitivity** – controls how much average pixel change inside the ROI is
+  required to trigger a camera event. Values are 0.0–1.0.
+- **dB Threshold** – minimum sound level needed to register a sound trigger.
+  Levels are measured using RMS and expressed in decibels.
+- **ROI** – drag or pinch the overlay to position and size the region of
+  interest used for motion detection.
+- **Minimum interval** – debounce time in milliseconds between counted events
+  from either detector.
+- **Debug overlay** – shows current motion intensity, sound level and a log of
+  the last 50 detections to assist with calibration.
+
+### Calibration tips
+
+- Adjust the ROI to cover only the area where motion should be detected.
+- Start with a low sensitivity / threshold and increase until false triggers
+  disappear.
+- Use headphones or a quiet room when calibrating the audio threshold.
+- Very noisy environments or low light may require higher debounce intervals.

--- a/app/src/main/java/com/example/svommeapp/detector/SoundDetector.kt
+++ b/app/src/main/java/com/example/svommeapp/detector/SoundDetector.kt
@@ -15,8 +15,7 @@ import kotlin.math.sqrt
  * exceeds a given threshold.
  */
 class SoundDetector(
-    private val thresholdDb: Int = 80,
-    private val onSound: () -> Unit
+    private val onLevel: (Double) -> Unit
 ) {
     private val sampleRate = 44100
     private val bufferSize = AudioRecord.getMinBufferSize(
@@ -43,11 +42,9 @@ class SoundDetector(
             while (true) {
                 val read = record?.read(buffer, 0, buffer.size) ?: break
                 if (read > 0) {
-                    val rms = sqrt(buffer.take(read).map { it * it }.average())
-                    val db = 20 * log10(rms / Short.MAX_VALUE)
-                    if (db > thresholdDb) {
-                        onSound()
-                    }
+                    val rms = sqrt(buffer.take(read).map { it.toDouble() * it.toDouble() }.average())
+                    val db = 20 * log10(rms.coerceAtLeast(1.0))
+                    onLevel(db)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix motion detector to report intensity for ROI frames
- use RMS sound level and expose audio intensity to app
- add start/stop button, debug overlay and event log

## Testing
- `gradle wrapper`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b0bc4ae08328aeb2901e4d231495