### PR TITLE
Tilføj reset, kameraskift og minimeret preview

### DIFF
--- a/app/src/main/java/com/example/svommeapp/CameraFacing.kt
+++ b/app/src/main/java/com/example/svommeapp/CameraFacing.kt
@@ -1,0 +1,4 @@
+package com.example.svommeapp
+
+enum class CameraFacing { BACK, FRONT }
+


### PR DESCRIPTION
## Summary
- Tilføj separat reset-knap med bekræftelse og bevar indstillinger.
- Implementer front/bag-kamera skift med individuelt ROI og husket tilstand.
- Gør kamera-view minimerbart og forstør metrics samt danske tekster.

## Testing
- `gradle test` *(fejlede: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f5944bb88328bccf54ee3fcb6624