### PR TITLE
Tilføj reset, kameraskift og minimeret preview

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,4 +51,5 @@ dependencies {
     implementation("androidx.camera:camera-lifecycle:1.3.0")
     implementation("androidx.camera:camera-view:1.3.0")
     implementation("com.google.accompanist:accompanist-permissions:0.32.0")
+    implementation("androidx.compose.material:material-icons-extended:1.5.1")
 }

--- a/app/src/main/java/com/example/svommeapp/CameraFacing.kt
+++ b/app/src/main/java/com/example/svommeapp/CameraFacing.kt
@@ -1,0 +1,4 @@
+package com.example.svommeapp
+
+enum class CameraFacing { BACK, FRONT }
+


### PR DESCRIPTION
## Summary
- Tilføj separat reset-knap med bekræftelse og bevar indstillinger.
- Implementer front/bag-kamera skift med individuelt ROI og husket tilstand.
- Gør kamera-view minimerbart og forstør metrics samt danske tekster.
- Tilføj `material-icons-extended` afhængighed for at understøtte kamera- og fuldskærm-ikoner.

## Testing
- `gradle assembleDebug` *(fejlede: SDK licenses not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f5944bb88328bccf54ee3fcb6624