### PR TITLE
Increase Gradle heap size

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
## Summary
- increase Gradle JVM heap to prevent OOM during dexing

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a20f83396c83288ab865f559fa8cbc