### PR TITLE
Handle camera preview minimize crash and add activation sound

### DIFF
--- a/app/src/main/java/com/example/svommeapp/LapCounterViewModel.kt
+++ b/app/src/main/java/com/example/svommeapp/LapCounterViewModel.kt
@@ -96,6 +96,12 @@ class LapCounterViewModel(app: Application) : AndroidViewModel(app) {
     private val _previewMinimized = MutableStateFlow(prefs.getBoolean("previewMinimized", false))
     val previewMinimized: StateFlow<Boolean> = _previewMinimized
 
+    private val _activationSoundUri = MutableStateFlow(prefs.getString("activationSoundUri", null))
+    val activationSoundUri: StateFlow<String?> = _activationSoundUri
+
+    private val _playSoundOnActivation = MutableStateFlow(prefs.getBoolean("playSoundOnActivation", true))
+    val playSoundOnActivation: StateFlow<Boolean> = _playSoundOnActivation
+
     fun setCameraEnabled(enabled: Boolean) {
         _cameraEnabled.value = enabled
         prefs.edit().putBoolean("cameraEnabled", enabled).apply()
@@ -175,6 +181,16 @@ class LapCounterViewModel(app: Application) : AndroidViewModel(app) {
     fun setPreviewMinimized(minimized: Boolean) {
         _previewMinimized.value = minimized
         prefs.edit().putBoolean("previewMinimized", minimized).apply()
+    }
+
+    fun setActivationSoundUri(uri: String?) {
+        _activationSoundUri.value = uri
+        prefs.edit().putString("activationSoundUri", uri).apply()
+    }
+
+    fun setPlaySoundOnActivation(enabled: Boolean) {
+        _playSoundOnActivation.value = enabled
+        prefs.edit().putBoolean("playSoundOnActivation", enabled).apply()
     }
 
     fun onTurnDetected(timestamp: Long = System.currentTimeMillis()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">SvommeApp</string>
+    <string name="app_name">Fars Svøm-o-meter</string>
 </resources>


### PR DESCRIPTION
## Summary
- Prevent crash when hiding camera by using a single preview with slide animation and arrow controls
- Allow activation sound selection and playback when app returns to foreground
- Make lap info panel scrollable and rename app to "Fars Svøm-o-meter"

## Testing
- `gradle wrapper`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2198485748328a8ffbac916df3228