### PR TITLE
Add lap audio cue and improve interval display

### DIFF
--- a/app/src/main/java/com/example/svommeapp/LapCounterViewModel.kt
+++ b/app/src/main/java/com/example/svommeapp/LapCounterViewModel.kt
@@ -3,6 +3,9 @@ package com.example.svommeapp
 import android.app.Application
 import android.content.Context
 import android.graphics.RectF
+import android.media.AudioAttributes
+import android.media.MediaPlayer
+import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -201,8 +204,29 @@ class LapCounterViewModel(app: Application) : AndroidViewModel(app) {
             val newLaps = _laps.value + 1
             _laps.emit(newLaps)
             _distanceMeters.emit(newLaps * _laneLengthMeters.value / _turnsPerLap.value)
-            val times = (_lastLapTimes.value + timestamp).takeLast(3)
+            val times = (_lastLapTimes.value + timestamp).takeLast(4)
             _lastLapTimes.emit(times)
+            playActivationSound()
+        }
+    }
+
+    private fun playActivationSound() {
+        if (!_playSoundOnActivation.value) return
+        val uri = _activationSoundUri.value ?: return
+        try {
+            val player = MediaPlayer()
+            player.setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_ASSISTANCE_SONIFICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .build()
+            )
+            player.setDataSource(getApplication(), Uri.parse(uri))
+            player.setOnCompletionListener { it.release() }
+            player.prepare()
+            player.start()
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
     }
 

--- a/app/src/main/java/com/example/svommeapp/MainActivity.kt
+++ b/app/src/main/java/com/example/svommeapp/MainActivity.kt
@@ -206,11 +206,29 @@ class MainActivity : ComponentActivity() {
                     .padding(8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                Button(onClick = { vm.toggleCounting() }, modifier = Modifier.weight(1f)) {
-                    Text(if (counting) "Stop" else "Start")
+                Button(
+                    onClick = { vm.toggleCounting() },
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(80.dp)
+                ) {
+                    Text(
+                        if (counting) "Stop" else "Start",
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold
+                    )
                 }
-                Button(onClick = { showReset = true }, modifier = Modifier.weight(1f)) {
-                    Text("Nulstil")
+                Button(
+                    onClick = { showReset = true },
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(80.dp)
+                ) {
+                    Text(
+                        "Nulstil",
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold
+                    )
                 }
             }
         }) { padding ->
@@ -251,11 +269,15 @@ class MainActivity : ComponentActivity() {
                                 onClick = {
                                     vm.setCameraFacing(if (cameraFacing == CameraFacing.BACK) CameraFacing.FRONT else CameraFacing.BACK)
                                 },
-                                enabled = hasFront && hasBack
+                                enabled = hasFront && hasBack,
+                                modifier = Modifier.size(80.dp)
                             ) {
                                 Icon(Icons.Default.Cameraswitch, contentDescription = "Skift kamera")
                             }
-                            IconButton(onClick = { vm.setPreviewMinimized(true) }) {
+                            IconButton(
+                                onClick = { vm.setPreviewMinimized(true) },
+                                modifier = Modifier.size(80.dp)
+                            ) {
                                 Icon(Icons.Default.KeyboardArrowUp, contentDescription = "Minimér kamera")
                             }
                         }
@@ -275,7 +297,10 @@ class MainActivity : ComponentActivity() {
                 }
                 if (previewMinimized) {
                     Box(Modifier.fillMaxWidth()) {
-                        IconButton(onClick = { vm.setPreviewMinimized(false) }, modifier = Modifier.align(Alignment.TopEnd)) {
+                        IconButton(
+                            onClick = { vm.setPreviewMinimized(false) },
+                            modifier = Modifier.align(Alignment.TopEnd).size(80.dp)
+                        ) {
                             Icon(Icons.Default.KeyboardArrowDown, contentDescription = "Vis kamera")
                         }
                     }
@@ -293,7 +318,7 @@ class MainActivity : ComponentActivity() {
                     Text("${distance} m", fontSize = if (previewMinimized) 96.sp else 48.sp, fontWeight = FontWeight.Bold)
                     Text("Afstand", fontSize = if (previewMinimized) 40.sp else 20.sp)
                     Text("Seneste 3 intervaller", fontWeight = FontWeight.Bold, modifier = Modifier.padding(top = 8.dp))
-                    val intervals = lapTimes.takeLast(3).zipWithNext { a, b -> b - a }
+                    val intervals = lapTimes.takeLast(4).zipWithNext { a, b -> b - a }
                     intervals.forEach { Text("${it/1000f}s", fontSize = if (previewMinimized) 64.sp else 32.sp) }
                 }
             }


### PR DESCRIPTION
## Summary
- Play selected sound on every detected lap
- Track four timestamps to always show three most recent intervals
- Increase primary button touch targets and text size for accessibility

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2257abb0883289fe1359753ec14fa