### PR TITLE
Fix playback, layout, and theme issues

### DIFF
--- a/app/src/main/java/com/example/svommeapp/ThemeMode.kt
+++ b/app/src/main/java/com/example/svommeapp/ThemeMode.kt
@@ -1,3 +1,0 @@
-package com.example.svommeapp
-
-enum class ThemeMode { AUTO, LIGHT, DARK }

--- a/app/src/main/java/com/example/svommeapp/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/svommeapp/ui/theme/Theme.kt
@@ -1,26 +1,11 @@
 package com.example.svommeapp.ui.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
-import androidx.compose.material.lightColors
 import androidx.compose.material.Shapes
 import androidx.compose.material.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import com.example.svommeapp.ThemeMode
-
-private val LightColors = lightColors(
-    primary = Color(0xFF0066CC),
-    primaryVariant = Color(0xFF004999),
-    secondary = Color(0xFF03DAC5),
-    background = Color(0xFFFDFDFD),
-    surface = Color(0xFFFFFFFF),
-    onPrimary = Color.White,
-    onSecondary = Color.Black,
-    onBackground = Color.Black,
-    onSurface = Color.Black,
-)
 
 private val DarkColors = darkColors(
     primary = Color(0xFF5B9BD5),
@@ -32,14 +17,9 @@ private val AppTypography = Typography()
 private val AppShapes = Shapes()
 
 @Composable
-fun SvommeTheme(mode: ThemeMode = ThemeMode.AUTO, content: @Composable () -> Unit) {
-    val darkTheme = when (mode) {
-        ThemeMode.LIGHT -> false
-        ThemeMode.DARK -> true
-        ThemeMode.AUTO -> isSystemInDarkTheme()
-    }
+fun SvommeTheme(content: @Composable () -> Unit) {
     MaterialTheme(
-        colors = if (darkTheme) DarkColors else LightColors,
+        colors = DarkColors,
         typography = AppTypography,
         shapes = AppShapes,
         content = content


### PR DESCRIPTION
## Summary
- Ensure activation sound always plays fully without overlaps
- Lock app to dark theme and remove theme settings
- Rework UI layout: keep stats visible, move status bar above controls, and allow ROI to reach edges

## Testing
- `./gradlew test` *(fails: Unable to access gradle wrapper jar)*

------
https://chatgpt.com/codex/tasks/task_e_68a24e0179148328bb430446ff14d433