### PR TITLE
Keep screen awake during lap counting

### DIFF
--- a/app/src/main/java/com/example/svommeapp/MainActivity.kt
+++ b/app/src/main/java/com/example/svommeapp/MainActivity.kt
@@ -76,7 +76,6 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalPermissionsApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         setContent {
             val permissions = rememberMultiplePermissionsState(
                 listOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
@@ -138,6 +137,17 @@ class MainActivity : ComponentActivity() {
         val previewMinimized by vm.previewMinimized.collectAsState()
         val activationSoundUri by vm.activationSoundUri.collectAsState()
         val playSoundOnActivation by vm.playSoundOnActivation.collectAsState()
+
+        DisposableEffect(counting) {
+            if (counting) {
+                window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            } else {
+                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+            onDispose {
+                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+        }
 
         val context = LocalContext.current
         val lifecycleOwner = LocalLifecycleOwner.current


### PR DESCRIPTION
## Summary
- Prevent the device from sleeping while lap counting is active by toggling the window's KEEP_SCREEN_ON flag during counting

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a256fdfcc08328ac9a6b23ec685e4b