### PR TITLE
Improve history management and export

### DIFF
--- a/app/src/main/java/com/example/svommeapp/LapCounterViewModel.kt
+++ b/app/src/main/java/com/example/svommeapp/LapCounterViewModel.kt
@@ -302,4 +302,16 @@ class LapCounterViewModel(app: Application) : AndroidViewModel(app) {
             lastTriggerTime = 0
         }
     }
+
+    fun deleteSession(id: Long) {
+        viewModelScope.launch {
+            dao.deleteSessionWithLaps(id)
+        }
+    }
+
+    fun deleteAllHistory() {
+        viewModelScope.launch {
+            dao.deleteAllSessionsWithLaps()
+        }
+    }
 }

--- a/app/src/main/java/com/example/svommeapp/data/LapDao.kt
+++ b/app/src/main/java/com/example/svommeapp/data/LapDao.kt
@@ -17,4 +17,28 @@ interface LapDao {
     @Transaction
     @Query("SELECT * FROM session ORDER BY startedAt DESC")
     fun getSessionsWithLaps(): Flow<List<SessionWithLaps>>
+
+    @Query("DELETE FROM lap WHERE sessionId = :sessionId")
+    suspend fun deleteLapsBySession(sessionId: Long)
+
+    @Query("DELETE FROM session WHERE id = :sessionId")
+    suspend fun deleteSessionById(sessionId: Long)
+
+    @Query("DELETE FROM lap")
+    suspend fun deleteAllLaps()
+
+    @Query("DELETE FROM session")
+    suspend fun deleteAllSessions()
+
+    @Transaction
+    suspend fun deleteSessionWithLaps(sessionId: Long) {
+        deleteLapsBySession(sessionId)
+        deleteSessionById(sessionId)
+    }
+
+    @Transaction
+    suspend fun deleteAllSessionsWithLaps() {
+        deleteAllLaps()
+        deleteAllSessions()
+    }
 }


### PR DESCRIPTION
## Summary
- enlarge fonts for "Seneste 3 intervaller"
- show totals and provide deletion options in history dialog
- export CSV timestamps in local ISO-8601 with unix ms columns

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a83970abb08328bd1f8991e4bc130f